### PR TITLE
Fix no seed warning when using parallel processing

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -7,7 +7,7 @@ run <- function(.x, .f, ..., .threads = 1, .skip = FALSE) {
     # TODO: consider using purrr::in_parallel() in the future when it's stable.
     future::plan(future::multisession, workers = .threads)
     res <- purrr::list_rbind(furrr::future_map(
-      .x = .x, .f = .f, ...
+      .x = .x, .f = .f, ..., .options = furrr::furrr_options(seed = TRUE)
     ))
   } else {
     res <- purrr::list_rbind(purrr::map(


### PR DESCRIPTION
In `run_eval()` it was possible for this warning message to pop up for some patients because we weren't setting a seed:

```
Warning messages:
1: UNRELIABLE VALUE: Future (<unnamed-4>) unexpectedly generated random numbers without specifying argument 'seed'. There is a risk that those random numbers are not statistically sound and the overall results might be invalid. To fix this, specify 'seed=TRUE'. This ensures that proper, parallel-safe random numbers are produced. To disable this check, use 'seed=NULL', or set option 'future.rng.onMisuse' to "ignore".
```

This PR sets a seed, which should silence the warning and ensure anything relying on RNG works safely with parallel processing.