### PR TITLE
Improve NA handling in error metrics and `calculate_stats()`

### DIFF
--- a/R/calculate_stats.R
+++ b/R/calculate_stats.R
@@ -46,7 +46,9 @@ calculate_stats <- function(
         NA
       )
     ) |>
-    dplyr::mutate(dplyr::across(dplyr::everything(), round, rounding)) |>
+    dplyr::mutate(
+      dplyr::across(dplyr::everything(), \(.x) round(.x, digits = rounding))
+    ) |>
     dplyr::as_tibble()
   class(out) <- c("mipdeval_results_stats_summ", class(out))
   out

--- a/R/misc.R
+++ b/R/misc.R
@@ -65,8 +65,8 @@ rmse <- function (obs, pred) {
 #'
 nrmse <- function (obs, pred) {
   res_sq <- (pred - obs)^2
-  rmse <- sqrt(mean(res_sq, na.rm = T))
-  rmse/mean(obs, na.rm = T)
+  rmse <- sqrt(mean(res_sq, na.rm = TRUE))
+  rmse/mean(obs, na.rm = TRUE)
 }
 
 #' Mean absolute percentage error
@@ -75,7 +75,7 @@ nrmse <- function (obs, pred) {
 #'
 #' @returns A numeric vector
 mape <- function (obs, pred) {
-  sum(abs((obs - pred))/obs)/length(obs)
+  mean(abs((obs - pred))/obs, na.rm = TRUE)
 }
 
 #' Mean percentage error
@@ -84,7 +84,7 @@ mape <- function (obs, pred) {
 #'
 #' @returns A numeric vector
 mpe <- function (obs, pred) {
-  sum((obs - pred)/obs)/length(obs)
+  mean((obs - pred)/obs, na.rm = TRUE)
 }
 
 #' Accuracy
@@ -123,7 +123,7 @@ mpe <- function (obs, pred) {
 #'
 #' @export
 accuracy <- function(obs, pred, error_abs = 0, error_rel = 0) {
-  mean(is_accurate(obs, pred, error_abs, error_rel))
+  mean(is_accurate(obs, pred, error_abs, error_rel), na.rm = TRUE)
 }
 
 #' @rdname accuracy

--- a/tests/testthat/test-calculate_stats.R
+++ b/tests/testthat/test-calculate_stats.R
@@ -1,3 +1,57 @@
+# calculate_stats() -----------------------------------------------------------
+test_that("calculate_stats() works", {
+  res <- data.frame(
+    id = c(1, 1, 2, 2),
+    apriori = c(FALSE, TRUE, FALSE, TRUE),
+    dv = c(10, 12, 8, 14),
+    pred = c(9, 13, 7, 15),
+    map_ipred = c(10, 11, 9, 13),
+    iter_ipred = c(11, 12, 8, 14)
+  )
+  out <- calculate_stats(res)
+
+  # One row per prediction type x apriori group:
+  expect_setequal(out$type, c("pred", "map_ipred", "iter_ipred"))
+  expect_setequal(out$apriori, c(TRUE, FALSE))
+  expect_equal(nrow(out), 6)
+
+  # Ensure that error metrics are computed separately apriori and aposteriori:
+  for (.apriori in c(TRUE, FALSE)) {
+    out_pred <- out[out$type == "pred" & out$apriori == .apriori, ]
+    res2 <- res[res$apriori == .apriori, ]
+    expect_equal(out_pred$rmse, round(rmse(res2$dv, res2$pred), 3))
+    expect_equal(out_pred$nrmse, round(nrmse(res2$dv, res2$pred), 3))
+    expect_equal(out_pred$mpe, round(mpe(res2$dv, res2$pred), 3))
+    expect_equal(out_pred$mape, round(mape(res2$dv, res2$pred), 3))
+    expect_true(is.na(out_pred$accuracy)) # NA by default
+  }
+
+  expect_s3_class(out, "mipdeval_results_stats_summ")
+  expect_s3_class(out, "tbl_df")
+})
+
+test_that("calculate_stats() warns when predictions contain errors (NAs)", {
+  res <- data.frame(
+    id = c(1, 1, 2, 2, 3, 3),
+    apriori = c(FALSE, TRUE, FALSE, TRUE, FALSE, TRUE),
+    dv = c(10, 12, NA, NA, 8, 14),
+    pred = c(9, 13, NA, NA, 7, 15),
+    map_ipred = c(10, 11, NA, NA, 9, 13),
+    iter_ipred = c(11, 12, NA, NA, 8, 14)
+  )
+  expect_warning(
+    out <- calculate_stats(res, acc_error_abs = 0.2, acc_error_rel = 0.05),
+    "Errors were encountered in 2 out of 6 evaluated predictions"
+  )
+
+  # Patients with errors should be ignored and metrics should be calculated:
+  expect_all_false(is.na(out$rmse))
+  expect_all_false(is.na(out$nrmse))
+  expect_all_false(is.na(out$mpe))
+  expect_all_false(is.na(out$mape))
+  expect_all_false(is.na(out$accuracy))
+})
+
 # stats_summ_options() --------------------------------------------------------
 test_that("stats_summ_options() works", {
   actual <- stats_summ_options(

--- a/tests/testthat/test-error_metrics.R
+++ b/tests/testthat/test-error_metrics.R
@@ -11,10 +11,16 @@ test_that("Normalized root mean squared error", {
   expect_equal(nrmse(obs, pred), sqrt(8.5)/ mean_obs)
 })
 
-test_that("Mean absolute percent error", {
+test_that("Mean absolute percentage error", {
   pred <- c(7, 10, 12, 10, 10, 8, 7,  8, 11, 13, 10, 8)
   obs  <- c(6, 10, 14, 16,  7, 5, 5, 13, 12, 13,  8, 5)
   expect_equal(round(mape(obs, pred), 3), 0.286)
+})
+
+test_that("Mean percentage error", {
+  pred <- c(7, 10, 12, 10, 10, 8, 7,  8, 11, 13, 10, 8)
+  obs  <- c(6, 10, 14, 16,  7, 5, 5, 13, 12, 13,  8, 5)
+  expect_equal(round(mpe(obs, pred), 3), -0.122)
 })
 
 test_that("Accuracy", {
@@ -41,5 +47,31 @@ test_that("Accuracy", {
       error_rel = 0.05
     ),
     0.6
+  )
+})
+
+test_that("error metrics ignore NA pairs", {
+  pred_na <- c(7, 10, NA, 12)
+  obs_na  <- c(6, 10, NA, 14)
+  pred    <- pred_na[!is.na(pred_na)]
+  obs     <- obs_na[!is.na(obs_na)]
+
+  # NAs are dropped, not propagated to the result:
+  expect_false(is.na(rmse(obs_na, pred_na)))
+  expect_false(is.na(nrmse(obs_na, pred_na)))
+  expect_false(is.na(mpe(obs_na, pred_na)))
+  expect_false(is.na(mape(obs_na, pred_na)))
+  expect_false(is.na(
+    accuracy(obs_na, pred_na, error_abs = 0.2, error_rel = 0.05)
+  ))
+
+  # Dropping NAs should match computing the metric on complete pairs:
+  expect_equal(rmse(obs_na, pred_na), rmse(obs, pred))
+  expect_equal(nrmse(obs_na, pred_na), nrmse(obs, pred))
+  expect_equal(mpe(obs_na, pred_na), mpe(obs, pred))
+  expect_equal(mape(obs_na, pred_na), mape(obs, pred))
+  expect_equal(
+    accuracy(obs_na, pred_na, error_abs = 0.2, error_rel = 0.05),
+    accuracy(obs, pred, error_abs = 0.2, error_rel = 0.05)
   )
 })


### PR DESCRIPTION
We weren't handling NAs consistently in our error metric functions (rmse, mpe, accuracy, etc.), which could lead to NAs showing up for mpe, mape, and accuracy in the `calculate_stats()` table if there were any fit failures in `run_eval()`. This PR ensures we handle NAs consistently across error metrics, so the `calculate_stats()` table will have results for each metric even when there were fit failures present.

I also fixed a deprecated `...` argument in `dplyr::across` inside `calculate_stats()`. 