### PR TITLE
add `_pkgdown.yml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 inst/doc
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,9 @@ Description: The package provides functionality to run through a
   specifically for use in MIPD, such as flattening priors, 
   time-based weighting, sample grouping, etc.
 License: MIT + file LICENSE
-Depends: 
+URL: https://insightrx.github.io/mipdeval, https://github.com/InsightRX/mipdeval
+BugReports: https://github.com/InsightRX/mipdeval/issues
+Depends:
     R (>= 4.2.0)
 Imports: 
     cli,

--- a/R/calculate_shrinkage.R
+++ b/R/calculate_shrinkage.R
@@ -51,6 +51,7 @@ calculate_shrinkage <- function(.res) {
 #' @param par_name name of parameter in model
 #' @param parameters list of parameter values, should include entry for
 #'   `par_name`
+#' @keywords internal
 calc_eta <- function(ind, par_name, parameters) {
   pop <- parameters[[par_name]]
   if(grepl("^kappa_", par_name) || pop == 0) { ## PAR = TV_PAR + ETA()
@@ -72,6 +73,7 @@ calc_shrinkage <- function(eta, par_name, om) {
 #' @inheritParams run_eval_core
 #'
 #' @returns list
+#' @keywords internal
 get_omega_for_parameters <- function(mod_obj) {
   pars <- names(mod_obj$parameters)
   pars <- pars[!(pars %in% mod_obj$fixed)]

--- a/R/check_failed_fits.R
+++ b/R/check_failed_fits.R
@@ -8,6 +8,7 @@
 #'   `data.frame` with raw results.
 #'
 #' @returns invisibly, a `data.frame` of the rows with failed predictions.
+#' @keywords internal
 check_failed_fits <- function(.res) {
   if(inherits(.res, "mipdeval_results")) {
     .res <- .res$results

--- a/R/check_input_data.R
+++ b/R/check_input_data.R
@@ -6,6 +6,7 @@
 #' @inheritParams run_eval
 #'
 #' @returns a data.frame
+#' @keywords internal
 check_input_data <- function(data, dictionary, verbose = TRUE) {
   if(verbose) cli::cli_progress_step("Checking integrity of input data")
   if(!is.null(dictionary) && length(dictionary) > 0) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -3,6 +3,7 @@
 #' @param model PKPDsim model object
 #'
 #' @returns A character vector of covariate names.
+#' @keywords internal
 get_required_covariates <- function(model) {
   unique(purrr::list_c(purrr::map(model, "covariates")))
 }
@@ -14,6 +15,7 @@ get_required_covariates <- function(model) {
 #' @param .cols vector of column names
 #'
 #' @returns A data.frame
+#' @keywords internal
 is_timevarying <- function(.data, .cols) {
   out <- dplyr::summarise(
     .data, dplyr::across(dplyr::all_of(.cols), \(.x) length(unique(.x)) > 1)
@@ -31,6 +33,7 @@ is_timevarying <- function(.data, .cols) {
 #' @inheritParams vctrs::vec_assert
 #'
 #' @returns Either throws an error or returns `x`, invisibly.
+#' @keywords internal
 vec_assert_or_null <- function(
     x,
     ptype = NULL,
@@ -152,6 +155,7 @@ is_accurate_rel <- function(obs, pred, error_rel = 0) {
 #' @inheritParams rmse
 #' @param w weights
 #'
+#' @keywords internal
 ss <- function(obs, pred, w = NULL) {
   if(is.null(w)) {
     w <- rep(1, length(obs))

--- a/R/parse_input_data.R
+++ b/R/parse_input_data.R
@@ -5,6 +5,7 @@
 #'
 #' @returns list of lists, within each list regimen, observations, and
 #' covariates
+#' @keywords internal
 parse_input_data <- function(
     data,
     covariates,

--- a/R/parse_model.R
+++ b/R/parse_model.R
@@ -7,6 +7,7 @@
 #' @inheritParams rlang::args_dots_used
 #'
 #' @returns A named list.
+#' @keywords internal
 parse_model <- function(model, ...) {
   rlang::check_dots_used()
   UseMethod("parse_model")
@@ -113,6 +114,7 @@ parse_model.PKPDsim <- function(
 #'
 #' @returns This function is called for its side effects and returns `NULL` if
 #'   the PKPDsim model library is installed or returns an error otherwise.
+#' @keywords internal
 check_installed_model_library <- function(model, call = rlang::caller_env()) {
   rlang::try_fetch(
     rlang::with_interactive(rlang::check_installed(model), value = FALSE),

--- a/R/print_functions.R
+++ b/R/print_functions.R
@@ -4,6 +4,7 @@
 #' @param ... further arguments passed to or from other methods.
 #'
 #' @export
+#' @keywords internal
 print.mipdeval_results <- function(x, ...) {
   if(is.null(x$results)) {
     cli::cli_alert_info("No forecasting info available, did you run with `vpc_only=TRUE`?")
@@ -20,6 +21,7 @@ print.mipdeval_results <- function(x, ...) {
 #' @param x stats summary object in output from `run_eval()`.
 #'
 #' @export
+#' @keywords internal
 print.mipdeval_results_stats_summ <- function(x, ...) {
   x |>
     dplyr::mutate(
@@ -39,6 +41,7 @@ print.mipdeval_results_stats_summ <- function(x, ...) {
 #' @param x shrinkage object in output from `run_eval()`.
 #'
 #' @export
+#' @keywords internal
 print.mipdeval_results_shrinkage <- function(x, ...) {
   x |>
     dplyr::rename("Iteration" = .data$`_iteration`) |>
@@ -52,6 +55,7 @@ print.mipdeval_results_shrinkage <- function(x, ...) {
 #' @param x bayesian impact object in output from `run_eval()`.
 #'
 #' @export
+#' @keywords internal
 print.mipdeval_results_bayesian_impact <- function(x, ...) {
   x |>
     rlang::set_names(gsub("bi_", "", names(x))) |>

--- a/R/read_input_data.R
+++ b/R/read_input_data.R
@@ -3,6 +3,7 @@
 #' @inheritParams run_eval
 #'
 #' @returns data.frame
+#' @keywords internal
 read_input_data <- function(data, verbose = TRUE) {
   if(verbose) cli::cli_progress_step("Reading input data")
   if(inherits(data, "character")) {

--- a/R/run_eval_core.R
+++ b/R/run_eval_core.R
@@ -7,6 +7,7 @@
 #'
 #' @returns a `data.frame` with individual predictions
 #'
+#' @keywords internal
 run_eval_core <- function(
   mod_obj,
   data,
@@ -228,7 +229,7 @@ run_eval_core <- function(
 #'
 #' @returns list with similar shape as `covariates` object, just
 #' with potentially censored future data.
-#'
+#' @keywords internal
 handle_covariate_censoring <- function(
   covariates,
   t,
@@ -257,7 +258,7 @@ handle_covariate_censoring <- function(
 #' @param i index
 #'
 #' @returns vector of weights (numeric)
-#'
+#' @keywords internal
 handle_sample_weighting <- function(
   obs_data,
   iterations,

--- a/R/run_vpc.R
+++ b/R/run_vpc.R
@@ -7,6 +7,7 @@
 #' @param seed Seed for random number generation.
 #'
 #' @returns data.frame
+#' @keywords internal
 run_vpc_core <- function(
     data,
     mod_obj,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,74 @@
+url: https://insightrx.github.io/mipdeval/
+
+development:
+  mode: auto
+
+template:
+  bootstrap: 5
+
+reference:
+- title: Run iterative predictive analysis
+  desc: >
+    All iterative predictive analyses begin with a call to `run_eval()`,
+    supplying a either a PKPDsim model object or library and a NONMEM-style
+    dataset.
+  contents:
+  - run_eval
+  - plot.mipdeval_results
+
+- title: Set options for iterative predictive analysis
+  desc: >
+    Pass these functions as arguments to `run_eval()` to set various options
+    for iterative predictive analysis, including the control of how and whether
+    various summary statistics are calculated.
+  contents:
+  - fit_options
+  - bootstrap_options
+  - stats_summ_options
+  - vpc_options
+
+- title: Calculate summary statistics for an iterative predictive analysis
+  desc: >
+    These functions calculate various summary statistics from the results of
+    `run_eval()`. All of these calculations can be included in the outputs of
+    `run_eval()` by setting various options; they are primarly exported here
+    for situations where additional post-processing is desired before running
+    calculations.
+  contents:
+  - calculate_bayesian_impact
+  - calculate_shrinkage
+  - calculate_stats
+  - calculate_bootstrap_summ
+
+- title: Group observations in a NONMEM dataset
+  desc: >
+    Helper functions for grouping observations in NONMEM datasets.
+  contents:
+  - add_grouping_column
+  - group_by_dose
+  - group_by_time
+
+- title: Built in datasets
+  desc:
+  contents:
+  - nm_busulfan
+  - nm_vanco
+
+- title: Bootstrapping and error metrics
+  desc: >
+    Lower-level functions for bootstrapping and calculating error metrics.
+  contents:
+  - bootstrap_metrics
+  - accuracy
+  - mape
+  - mpe
+  - nrmse
+  - rmse
+
+- title: Compare results with PsN
+  desc: >
+    Helper functions to compare the results of `run_eval()` with the PsN
+    `execute` and `proseval` tools.
+  contents:
+  - compare-psn-results
+  - parse_psn_proseval_results

--- a/man/calc_eta.Rd
+++ b/man/calc_eta.Rd
@@ -23,3 +23,4 @@ shape for IIV, i.e. \code{PAR = TV_PAR * EXP(ETA(n))}, and
 additive shape for IOV (kappa's), i.e. \code{PAR = TV_PAR + ETA(n)} or when
 final parameter estimate is 0.
 }
+\keyword{internal}

--- a/man/check_failed_fits.Rd
+++ b/man/check_failed_fits.Rd
@@ -18,3 +18,4 @@ Detects predictions that came back as \code{NA}, which indicates the underlying
 MAP Bayesian fit failed, and---when \code{warn = TRUE}---emits a warning
 summarising how many predictions failed and in which subjects.
 }
+\keyword{internal}

--- a/man/check_input_data.Rd
+++ b/man/check_input_data.Rd
@@ -21,3 +21,4 @@ a data.frame
 E.g. confirm that all required columns are included, and column names are
 all lower-case.
 }
+\keyword{internal}

--- a/man/check_installed_model_library.Rd
+++ b/man/check_installed_model_library.Rd
@@ -30,3 +30,4 @@ the PKPDsim model library is installed or returns an error otherwise.
 \description{
 Check if PKPDsim model library is installed
 }
+\keyword{internal}

--- a/man/get_omega_for_parameters.Rd
+++ b/man/get_omega_for_parameters.Rd
@@ -15,3 +15,4 @@ list
 \description{
 Return all diagonal om^2 elements for each non-fixed parameter, as a list
 }
+\keyword{internal}

--- a/man/get_required_covariates.Rd
+++ b/man/get_required_covariates.Rd
@@ -15,3 +15,4 @@ A character vector of covariate names.
 \description{
 Get required covariates from a PKPDsim model object
 }
+\keyword{internal}

--- a/man/handle_covariate_censoring.Rd
+++ b/man/handle_covariate_censoring.Rd
@@ -21,3 +21,4 @@ with potentially censored future data.
 \description{
 This removes new covariate information after a certain time cutoff
 }
+\keyword{internal}

--- a/man/handle_sample_weighting.Rd
+++ b/man/handle_sample_weighting.Rd
@@ -29,3 +29,4 @@ This function is used to select the samples used in the fit (1 or 0),
 but also to select their weight, if a sample weighting strategy is
 selected.
 }
+\keyword{internal}

--- a/man/is_timevarying.Rd
+++ b/man/is_timevarying.Rd
@@ -19,3 +19,4 @@ A data.frame
 For requested columns in a dataset, check if values vary or not across
 rows
 }
+\keyword{internal}

--- a/man/mipdeval-package.Rd
+++ b/man/mipdeval-package.Rd
@@ -8,6 +8,15 @@
 \description{
 The package provides functionality to run through a NONMEM-style dataset iteratively, performing MAP Bayesian updating and forecasting at each step. This is very much like the `proseval` tool in PsN, however this package provides more options, specifically for use in MIPD, such as flattening priors, time-based weighting, sample grouping, etc.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://insightrx.github.io/mipdeval}
+  \item \url{https://github.com/InsightRX/mipdeval}
+  \item Report bugs at \url{https://github.com/InsightRX/mipdeval/issues}
+}
+
+}
 \author{
 \strong{Maintainer}: Ron Keizer \email{ron@insight-rx.com}
 

--- a/man/parse_input_data.Rd
+++ b/man/parse_input_data.Rd
@@ -29,3 +29,4 @@ covariates
 \description{
 Parse NONMEM-style input data, prepare for main eval loop
 }
+\keyword{internal}

--- a/man/parse_model.Rd
+++ b/man/parse_model.Rd
@@ -47,3 +47,4 @@ A named list.
 Parse model information from PKPDsim model object or an installed PKPDsim
 model library.
 }
+\keyword{internal}

--- a/man/print.mipdeval_results.Rd
+++ b/man/print.mipdeval_results.Rd
@@ -14,3 +14,4 @@
 \description{
 Print results from run_eval()
 }
+\keyword{internal}

--- a/man/print.mipdeval_results_bayesian_impact.Rd
+++ b/man/print.mipdeval_results_bayesian_impact.Rd
@@ -14,3 +14,4 @@
 \description{
 Print Bayesian impact results from run_eval()
 }
+\keyword{internal}

--- a/man/print.mipdeval_results_shrinkage.Rd
+++ b/man/print.mipdeval_results_shrinkage.Rd
@@ -14,3 +14,4 @@
 \description{
 Print shrinkage results from run_eval()
 }
+\keyword{internal}

--- a/man/print.mipdeval_results_stats_summ.Rd
+++ b/man/print.mipdeval_results_stats_summ.Rd
@@ -14,3 +14,4 @@
 \description{
 Print predictive performance statistics from run_eval()
 }
+\keyword{internal}

--- a/man/read_input_data.Rd
+++ b/man/read_input_data.Rd
@@ -17,3 +17,4 @@ data.frame
 \description{
 Read input data
 }
+\keyword{internal}

--- a/man/run_eval_core.Rd
+++ b/man/run_eval_core.Rd
@@ -58,3 +58,4 @@ a \code{data.frame} with individual predictions
 Core iterative simulation and MAP estimation function that loops over
 an individual's dataset
 }
+\keyword{internal}

--- a/man/run_vpc_core.Rd
+++ b/man/run_vpc_core.Rd
@@ -25,3 +25,4 @@ data.frame
 Core function for creating visual predictive checks (VPCs). Runs \code{n_samples}
 simulations for a single subject
 }
+\keyword{internal}

--- a/man/ss.Rd
+++ b/man/ss.Rd
@@ -16,3 +16,4 @@ ss(obs, pred, w = NULL)
 \description{
 Weighted sum-of-squares of residuals
 }
+\keyword{internal}

--- a/man/vec_assert_or_null.Rd
+++ b/man/vec_assert_or_null.Rd
@@ -37,3 +37,4 @@ Either throws an error or returns \code{x}, invisibly.
 \description{
 Assert an argument has known prototype and/or size or is NULL
 }
+\keyword{internal}


### PR DESCRIPTION
This PR adds a `_pkgdown.yml` file to improve the organization of our pkgdown site. I also marked several internal functions with `@keywords internal` to prevent their documentation from surfacing.